### PR TITLE
feat: add complex xquery support

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,57 +1,57 @@
 {
-  "dependencies": {
-    "obs-studio": {
-      "version": "29.1.2",
-      "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
-      "label": "OBS sources",
-      "hashes": {
-        "macos": "215f1fa5772c5dd9f3d6e35b0cb573912b00320149666a77864f9d305525504b",
-        "windows-x64": "46d451f3f42b9d2c59339ec268165849c7b7904cdf1cc2a8d44c015815a9e37d"
-      }
+    "dependencies": {
+        "obs-studio": {
+            "version": "29.1.2",
+            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+            "label": "OBS sources",
+            "hashes": {
+                "macos": "215f1fa5772c5dd9f3d6e35b0cb573912b00320149666a77864f9d305525504b",
+                "windows-x64": "46d451f3f42b9d2c59339ec268165849c7b7904cdf1cc2a8d44c015815a9e37d"
+            }
+        },
+        "prebuilt": {
+            "version": "2023-04-12",
+            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+            "label": "Pre-Built obs-deps",
+            "hashes": {
+                "macos": "9535c6e1ad96f7d49960251e85a245774088d48da1d602bb82f734b10219125a",
+                "windows-x64": "c13a14a1acc4224b21304d97b63da4121de1ed6981297e50496fbc474abc0503"
+            }
+        },
+        "qt6": {
+            "version": "2023-04-12",
+            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+            "label": "Pre-Built Qt6",
+            "hashes": {
+                "macos": "eb7614544ab4f3d2c6052c797635602280ca5b028a6b987523d8484222ce45d1",
+                "windows-x64": "4d39364b8a8dee5aa24fcebd8440d5c22bb4551c6b440ffeacce7d61f2ed1add"
+            },
+            "debugSymbols": {
+                "windows-x64": "f34ee5067be19ed370268b15c53684b7b8aaa867dc800b68931df905d679e31f"
+            }
+        }
     },
-    "prebuilt": {
-      "version": "2023-04-12",
-      "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-      "label": "Pre-Built obs-deps",
-      "hashes": {
-        "macos": "9535c6e1ad96f7d49960251e85a245774088d48da1d602bb82f734b10219125a",
-        "windows-x64": "c13a14a1acc4224b21304d97b63da4121de1ed6981297e50496fbc474abc0503"
-      }
+    "tools": {
+        "packages": {
+            "version": "1.2.10",
+            "baseUrl": "http://s.sudre.free.fr/Software/files",
+            "label": "Packages.app",
+            "hash": "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
+        }
     },
-    "qt6": {
-      "version": "2023-04-12",
-      "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-      "label": "Pre-Built Qt6",
-      "hashes": {
-        "macos": "eb7614544ab4f3d2c6052c797635602280ca5b028a6b987523d8484222ce45d1",
-        "windows-x64": "4d39364b8a8dee5aa24fcebd8440d5c22bb4551c6b440ffeacce7d61f2ed1add"
-      },
-      "debugSymbols": {
-        "windows-x64": "f34ee5067be19ed370268b15c53684b7b8aaa867dc800b68931df905d679e31f"
-      }
+    "platformConfig": {
+        "macos": {
+            "bundleId": "com.royshilkrot.obs-urlsource"
+        }
+    },
+    "name": "obs-urlsource",
+    "version": "0.1.1",
+    "author": "Roy Shilkrot",
+    "website": "https://github.com/royshil/obs-urlsource",
+    "email": "roy.shil@gmail.com",
+    "uuids": {
+        "macosPackage": "00000000-0000-0000-0000-000000000000",
+        "macosInstaller": "00000000-0000-0000-0000-000000000000",
+        "windowsApp": "00000000-0000-0000-0000-000000000000"
     }
-  },
-  "tools": {
-    "packages": {
-      "version": "1.2.10",
-      "baseUrl": "http://s.sudre.free.fr/Software/files",
-      "label": "Packages.app",
-      "hash": "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
-    }
-  },
-  "platformConfig": {
-    "macos": {
-      "bundleId": "com.royshilkrot.obs-urlsource"
-    }
-  },
-  "name": "obs-urlsource",
-  "version": "0.1.1",
-  "author": "Roy Shilkrot",
-  "website": "https://github.com/royshil/obs-urlsource",
-  "email": "roy.shil@gmail.com",
-  "uuids": {
-    "macosPackage": "00000000-0000-0000-0000-000000000000",
-    "macosInstaller": "00000000-0000-0000-0000-000000000000",
-    "windowsApp": "00000000-0000-0000-0000-000000000000"
-  }
 }

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,57 +1,57 @@
 {
-    "dependencies": {
-        "obs-studio": {
-            "version": "29.1.2",
-            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
-            "label": "OBS sources",
-            "hashes": {
-                "macos": "215f1fa5772c5dd9f3d6e35b0cb573912b00320149666a77864f9d305525504b",
-                "windows-x64": "46d451f3f42b9d2c59339ec268165849c7b7904cdf1cc2a8d44c015815a9e37d"
-            }
-        },
-        "prebuilt": {
-            "version": "2023-04-12",
-            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-            "label": "Pre-Built obs-deps",
-            "hashes": {
-                "macos": "9535c6e1ad96f7d49960251e85a245774088d48da1d602bb82f734b10219125a",
-                "windows-x64": "c13a14a1acc4224b21304d97b63da4121de1ed6981297e50496fbc474abc0503"
-            }
-        },
-        "qt6": {
-            "version": "2023-04-12",
-            "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
-            "label": "Pre-Built Qt6",
-            "hashes": {
-                "macos": "eb7614544ab4f3d2c6052c797635602280ca5b028a6b987523d8484222ce45d1",
-                "windows-x64": "4d39364b8a8dee5aa24fcebd8440d5c22bb4551c6b440ffeacce7d61f2ed1add"
-            },
-            "debugSymbols": {
-                "windows-x64": "f34ee5067be19ed370268b15c53684b7b8aaa867dc800b68931df905d679e31f"
-            }
-        }
+  "dependencies": {
+    "obs-studio": {
+      "version": "29.1.2",
+      "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+      "label": "OBS sources",
+      "hashes": {
+        "macos": "215f1fa5772c5dd9f3d6e35b0cb573912b00320149666a77864f9d305525504b",
+        "windows-x64": "46d451f3f42b9d2c59339ec268165849c7b7904cdf1cc2a8d44c015815a9e37d"
+      }
     },
-    "tools": {
-        "packages": {
-            "version": "1.2.10",
-            "baseUrl": "http://s.sudre.free.fr/Software/files",
-            "label": "Packages.app",
-            "hash": "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
-        }
+    "prebuilt": {
+      "version": "2023-04-12",
+      "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+      "label": "Pre-Built obs-deps",
+      "hashes": {
+        "macos": "9535c6e1ad96f7d49960251e85a245774088d48da1d602bb82f734b10219125a",
+        "windows-x64": "c13a14a1acc4224b21304d97b63da4121de1ed6981297e50496fbc474abc0503"
+      }
     },
-    "platformConfig": {
-        "macos": {
-            "bundleId": "com.royshilkrot.obs-urlsource"
-        }
-    },
-    "name": "obs-urlsource",
-    "version": "0.1.0",
-    "author": "Roy Shilkrot",
-    "website": "https://github.com/royshil/obs-urlsource",
-    "email": "roy.shil@gmail.com",
-    "uuids": {
-        "macosPackage": "00000000-0000-0000-0000-000000000000",
-        "macosInstaller": "00000000-0000-0000-0000-000000000000",
-        "windowsApp": "00000000-0000-0000-0000-000000000000"
+    "qt6": {
+      "version": "2023-04-12",
+      "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
+      "label": "Pre-Built Qt6",
+      "hashes": {
+        "macos": "eb7614544ab4f3d2c6052c797635602280ca5b028a6b987523d8484222ce45d1",
+        "windows-x64": "4d39364b8a8dee5aa24fcebd8440d5c22bb4551c6b440ffeacce7d61f2ed1add"
+      },
+      "debugSymbols": {
+        "windows-x64": "f34ee5067be19ed370268b15c53684b7b8aaa867dc800b68931df905d679e31f"
+      }
     }
+  },
+  "tools": {
+    "packages": {
+      "version": "1.2.10",
+      "baseUrl": "http://s.sudre.free.fr/Software/files",
+      "label": "Packages.app",
+      "hash": "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
+    }
+  },
+  "platformConfig": {
+    "macos": {
+      "bundleId": "com.royshilkrot.obs-urlsource"
+    }
+  },
+  "name": "obs-urlsource",
+  "version": "0.1.1",
+  "author": "Roy Shilkrot",
+  "website": "https://github.com/royshil/obs-urlsource",
+  "email": "roy.shil@gmail.com",
+  "uuids": {
+    "macosPackage": "00000000-0000-0000-0000-000000000000",
+    "macosInstaller": "00000000-0000-0000-0000-000000000000",
+    "windowsApp": "00000000-0000-0000-0000-000000000000"
+  }
 }

--- a/src/request-data.cpp
+++ b/src/request-data.cpp
@@ -303,7 +303,8 @@ struct request_data_handler_response request_data_handler(url_source_request_dat
 	// Parse the response
 	if (request_data->output_type == "JSON") {
 		response = parse_json(response, request_data);
-	} else if (request_data->output_type == "XML" || request_data->output_type == "HTML") {
+	} else if (request_data->output_type == "XML (XPath)" ||
+		   request_data->output_type == "HTML") {
 		response = parse_xml(response, request_data);
 	} else if (request_data->output_type == "XML (XQuery)") {
 		response = parse_xml_by_xquery(response, request_data);

--- a/src/request-data.cpp
+++ b/src/request-data.cpp
@@ -341,6 +341,7 @@ std::string serialize_request_data(url_source_request_data *request_data)
 	json["output_type"] = request_data->output_type;
 	json["output_json_path"] = request_data->output_json_path;
 	json["output_xpath"] = request_data->output_xpath;
+	json["output_xquery"] = request_data->output_xquery;
 	json["output_regex"] = request_data->output_regex;
 	json["output_regex_flags"] = request_data->output_regex_flags;
 	json["output_regex_group"] = request_data->output_regex_group;
@@ -410,6 +411,7 @@ url_source_request_data unserialize_request_data(std::string serialized_request_
 	request_data.output_type = json["output_type"].get<std::string>();
 	request_data.output_json_path = json["output_json_path"].get<std::string>();
 	request_data.output_xpath = json["output_xpath"].get<std::string>();
+	request_data.output_xquery = json["output_xquery"].get<std::string>();
 	request_data.output_regex = json["output_regex"].get<std::string>();
 	request_data.output_regex_flags = json["output_regex_flags"].get<std::string>();
 	request_data.output_regex_group = json["output_regex_group"].get<std::string>();

--- a/src/request-data.h
+++ b/src/request-data.h
@@ -29,6 +29,7 @@ struct url_source_request_data {
 	std::string output_type;
 	std::string output_json_path;
 	std::string output_xpath;
+	std::string output_xquery;
 	std::string output_regex;
 	std::string output_regex_flags;
 	std::string output_regex_group;
@@ -48,6 +49,7 @@ struct url_source_request_data {
 		output_type = std::string("text");
 		output_json_path = std::string("");
 		output_xpath = std::string("");
+		output_xquery = std::string("");
 		output_regex = std::string("");
 		output_regex_flags = std::string("");
 		output_regex_group = std::string("0");
@@ -68,6 +70,7 @@ struct url_source_request_data {
 		output_type = std::string(other.output_type);
 		output_json_path = std::string(other.output_json_path);
 		output_xpath = std::string(other.output_xpath);
+		output_xquery = std::string(other.output_xquery);
 		output_regex = std::string(other.output_regex);
 		output_regex_flags = std::string(other.output_regex_flags);
 		output_regex_group = std::string(other.output_regex_group);
@@ -88,6 +91,7 @@ struct url_source_request_data {
 		output_type = std::string(other.output_type);
 		output_json_path = std::string(other.output_json_path);
 		output_xpath = std::string(other.output_xpath);
+		output_xquery = std::string(other.output_xquery);
 		output_regex = std::string(other.output_regex);
 		output_regex_flags = std::string(other.output_regex_flags);
 		output_regex_group = std::string(other.output_regex_group);

--- a/src/ui/RequestBuilder.cpp
+++ b/src/ui/RequestBuilder.cpp
@@ -331,7 +331,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 	QComboBox *outputTypeComboBox = new QComboBox;
 	outputTypeComboBox->addItem("Text");
 	outputTypeComboBox->addItem("JSON");
-	outputTypeComboBox->addItem("XML");
+	outputTypeComboBox->addItem("XML (XPath)");
 	outputTypeComboBox->addItem("XML (XQuery)");
 	outputTypeComboBox->addItem("HTML");
 	outputTypeComboBox->setCurrentIndex(
@@ -375,7 +375,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 		// Show the output parsing options for the selected output type
 		if (outputTypeComboBox->currentText() == "JSON") {
 			set_form_row_visibility(formOutputParsing, outputJSONPathLineEdit, true);
-		} else if (outputTypeComboBox->currentText() == "XML" ||
+		} else if (outputTypeComboBox->currentText() == "XML (XPath)" ||
 			   outputTypeComboBox->currentText() == "HTML") {
 			set_form_row_visibility(formOutputParsing, outputXPathLineEdit, true);
 		} else if (outputTypeComboBox->currentText() == "XML (XQuery)") {

--- a/src/ui/RequestBuilder.cpp
+++ b/src/ui/RequestBuilder.cpp
@@ -332,6 +332,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 	outputTypeComboBox->addItem("Text");
 	outputTypeComboBox->addItem("JSON");
 	outputTypeComboBox->addItem("XML");
+	outputTypeComboBox->addItem("XML (XQuery)");
 	outputTypeComboBox->addItem("HTML");
 	outputTypeComboBox->setCurrentIndex(
 		outputTypeComboBox->findText(QString::fromStdString(request_data->output_type)));
@@ -345,6 +346,10 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 	outputXPathLineEdit->setText(QString::fromStdString(request_data->output_xpath));
 	outputXPathLineEdit->setPlaceholderText("XPath");
 	formOutputParsing->addRow("XPath", outputXPathLineEdit);
+	QLineEdit *outputXQueryLineEdit = new QLineEdit;
+	outputXQueryLineEdit->setText(QString::fromStdString(request_data->output_xquery));
+	outputXQueryLineEdit->setPlaceholderText("XQuery");
+	formOutputParsing->addRow("XQuery", outputXQueryLineEdit);
 	QLineEdit *outputRegexLineEdit = new QLineEdit;
 	outputRegexLineEdit->setText(QString::fromStdString(request_data->output_regex));
 	outputRegexLineEdit->setPlaceholderText("Regex");
@@ -362,6 +367,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 		// Hide all output parsing options
 		set_form_row_visibility(formOutputParsing, outputJSONPathLineEdit, false);
 		set_form_row_visibility(formOutputParsing, outputXPathLineEdit, false);
+		set_form_row_visibility(formOutputParsing, outputXQueryLineEdit, false);
 		set_form_row_visibility(formOutputParsing, outputRegexLineEdit, false);
 		set_form_row_visibility(formOutputParsing, outputRegexFlagsLineEdit, false);
 		set_form_row_visibility(formOutputParsing, outputRegexGroupLineEdit, false);
@@ -372,6 +378,8 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 		} else if (outputTypeComboBox->currentText() == "XML" ||
 			   outputTypeComboBox->currentText() == "HTML") {
 			set_form_row_visibility(formOutputParsing, outputXPathLineEdit, true);
+		} else if (outputTypeComboBox->currentText() == "XML (XQuery)") {
+			set_form_row_visibility(formOutputParsing, outputXQueryLineEdit, true);
 		} else if (outputTypeComboBox->currentText() == "Text") {
 			set_form_row_visibility(formOutputParsing, outputRegexLineEdit, true);
 			set_form_row_visibility(formOutputParsing, outputRegexFlagsLineEdit, true);
@@ -434,6 +442,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 		request_data_for_saving->output_json_path =
 			outputJSONPathLineEdit->text().toStdString();
 		request_data_for_saving->output_xpath = outputXPathLineEdit->text().toStdString();
+		request_data_for_saving->output_xquery = outputXQueryLineEdit->text().toStdString();
 		request_data_for_saving->output_regex = outputRegexLineEdit->text().toStdString();
 		request_data_for_saving->output_regex_flags =
 			outputRegexFlagsLineEdit->text().toStdString();


### PR DESCRIPTION
Added support for complex XQuery usage.

e.g.

An XML from [Ross Dashboard](https://www.rossvideo.com/control-systems/enterprise-control-systems/dashboard/)
```
<?xml version="1.1" encoding="UTF-8"?>
<card autosave="true" online="true" slot="1"
     sourceframename="Frame"
     status="0" statustext="OK" version="2.0">
     <params>
          <param access="1" maxlength="0" name="CountdownValue" oid="1"
               type="STRING" value="00:00" widget="label"/>
          <param access="1" constrainttype="INT_NULL" name="TargetTime"
               oid="2" precision="0" strvalue="0" type="INT32" value="0" widget="default"/>
          <param access="1" maxlength="0" name="CountdownToTarget"
               oid="3" type="STRING" value="936:33" widget="label"/>
          <param access="1" maxlength="0" name="DateTime" oid="1001"
               type="STRING" value="2023-09-29 02:23:26" widget="label"/>
          <param access="1" constrainttype="INT_NULL"
               name="InputCountdown" oid="4" precision="0"
               strvalue="181" type="INT32" value="181" widget="default"/>
          <param access="1" constrainttype="INT_NULL"
               name="InputTargetHout" oid="5" precision="0"
               strvalue="20" type="INT32" value="20" widget="default"/>
          <param access="1" constrainttype="INT_NULL"
               name="InputTargetMinute" oid="6" precision="0"
               strvalue="38" type="INT32" value="38" widget="default"/>
          <param access="1" constrainttype="INT_NULL"
               name="InputTargetSecond" oid="7" precision="0"
               strvalue="0" type="INT32" value="0" widget="default"/>
     </params>
     <statsmenu menuid="0" name="status"/>
     <configmenu menuid="1" name="config"/>
</card>
```

With XQuery str `//param[@oid=3]/@value` will get the result like
![image](https://github.com/obs-ai/obs-urlsource/assets/24890691/c23b2060-0340-4598-9291-f85ae8e6cc79)

Other XQuery methods such as `sum` or `count` is also available
![image](https://github.com/obs-ai/obs-urlsource/assets/24890691/d7194062-65a1-474b-9bac-efdcfc62d218)
![image](https://github.com/obs-ai/obs-urlsource/assets/24890691/8e8f63b3-a15b-475d-b467-58d49f832452)

